### PR TITLE
feat: added custom parameter addition from routes.js directly

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,5 @@
 # Swagger Generator Sails Hook
-[![Travis](https://img.shields.io/travis/theo4u/sails-hook-swagger-generator.svg)](https://travis-ci.org/theo4u/sails-hook-swagger-generator)
+[![Travis](https://img.shields.io/travis/theo4u/sails-hook-swagger-generator.svg)]()
 [![npm](https://img.shields.io/npm/v/sails-hook-swagger-generator.svg)](https://www.npmjs.com/package/sails-hook-swagger-generator)
 [![npm](https://img.shields.io/npm/l/express.svg)]()
 
@@ -27,7 +27,6 @@ check the **./swagger/swagger.json** for sample generated swagger documentation 
 It comes with some default settings which can be override by creating **config/swaggergenerator.js**
 ```javascript
 module.exports["swagger-generator"] = {
-    disabled: false,
     swaggerJsonPath: "./swagger/swagger.json",
     parameters: { //we can add up custom parameters here
         PerPageQueryParam: {
@@ -55,7 +54,6 @@ module.exports["swagger-generator"] = {
     }
 };
 ```
-* **disabled** attribute is used to disable the module. (e.g you may want to disable it on production)
 * **swaggerJsonPath** where to generate the `swagger.json` file to, default to `sails.config.appPath + "/swagger/swagger.json"`
 * **parameters** we can create your own custom parameter to be referenced by api service methods and it's totally based on swagger specification for parameter object. Any one added here is added to the default parameters which are
 ```javascript
@@ -136,24 +134,35 @@ If you want to add extra configuration to a route, it can be done via the `confi
 * `'http_method route':'controller.action'` or
 * `'http_method route':{controller:'controller', action:'action'}`
 
-We can extend and add extra information on the second above for sails hook swagger generator to override default properties(which is created from the first). Adding an object with a key **swagger** will do the trick.
+We can extend and add extra information on the second above for sails hook swagger generator to override default properties(which is created from the first). Adding an object with a key **swagger** will do the trick.We can also add custom personalized `parameters` if required.
+
 ```javascript
 {
-    'post /user/login': {
-        controller: 'UserController',
-            action: 'login',
-            swagger: {
-           		summary: 'Authentication',
-                description: 'This is for authentication of any user',
-                body: {
-                        username: { type: 'string', required: true },
-                        password: { type: 'password', required: true }
-                     },
-            query: [{ $ref: '#/parameters/IDPathParam' }]
-        }
+  'post /user/login': {
+    controller: 'UserController',
+    action: 'login',
+    swagger: {
+      summary: 'Authentication',
+      description: 'This is for authentication of any user',
+      body: {
+        username: { type: 'string', required: true },
+        password: { type: 'password', required: true }
+      },
+      query: [{
+        $ref: '#/parameters/IDPathParam'
+      }],
+      parameters: [{
+        in: 'query',
+        name: 'firstName',
+        required: true,
+        type: 'string',
+        description: 'This is a custom required parameter'
+      }]
     }
+  }
 }
 ```
+
 ### Properties of swagger
 * **summary**: for adding your own custom summary, e.g Authentication
 * **description**: for giving detailed description about the api service method, e.g This is for authentication of any type of user
@@ -191,4 +200,3 @@ See the different releases [here](https://github.com/theo4u/sails-hook-swagger-g
 ## License
 
 MIT License (MIT)
-

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -128,7 +128,6 @@ function _generateParameters(config, context) {
         description: 'This is to identify a particular object out'
     };
 
-
     //now we extend our config.swaggerDoc.parameters
     return _.merge(params, config[context.configKey].parameters);
 }
@@ -237,14 +236,12 @@ function _generatePaths(generated_routes, tags, customBlueprintMaps) {
     _.forEach(generated_routes, function (routes, identity) {
         _.forEach(routes, function (route) {
 
-
             var tag = _.find(tags, {identity: identity});
 
             if (!tag) {
                 //   throw new Error("No tag for this identity-" + identity); --> some controller exist without model
                 console.warn("No tag for this identity '" + identity + "'");
             }
-
 
             var parameter = formatter.blueprint_parameter(route.action, customBlueprintMaps);
             if (!parameter) //which means is not in our parameters, then use the keys to get and add token for us incase of any route using header information
@@ -256,14 +253,15 @@ function _generatePaths(generated_routes, tags, customBlueprintMaps) {
                 tags: tag ? [tag.name] : [identity],
                 produces: ['application/json'],
                 consumes: ['application/json'],
-                parameters: parameter.concat(_getQueryParamsFromRouteQuery(route.query)).concat(_getBodyParamsFromRouteBody(route.body)),
+                parameters: parameter.concat(_getQueryParamsFromParameters(route.parameters))
+                                     .concat(_getQueryParamsFromRouteQuery(route.query))
+                                     .concat(_getBodyParamsFromRouteBody(route.body)),
                 responses: {
                     '200': {description: 'The requested resource'},
                     '404': {description: 'Resource not found'},
                     '500': {description: 'Internal server error'}
                 }
             };
-
             //for our route that alters db we need json form body
             if (route.action === "create" || route.action === "update") {
                 path.parameters.push({
@@ -347,6 +345,28 @@ function _getPathParamsFromKeys(keys) {
 }
 
 /**
+ * this is used to create param for custom controllers
+ * @param parameters
+ * @returns {Array}
+ * @private
+ */
+function _getQueryParamsFromParameters(parameters) {
+    var params = [];
+
+    _.forEach(parameters, function (parameter) {
+        params.push({
+            in: parameter.in || 'parameters',
+            name: parameter.name,
+            required: parameter.required || false,
+            type: parameter.type || 'string',
+            description: parameter.description || 'This is a custom param for ' + parameter.name
+        });
+    });
+
+    return params;
+}
+
+/**
  * this is used to create param or custom queries for our request or route path
  * @param queries
  * @returns {Array}
@@ -398,4 +418,3 @@ module.exports = {
     routes: _generateRoutes,
     paths: _generatePaths
 };
-


### PR DESCRIPTION
It will allow us to add parameters to our custom routes like this,
```
     'POST /client': {
     controller: 'ClientController',
        action: 'createClient',
        swagger: {
	    summary: 'Client creation',
	    description: 'This is for creating client for HMAC Authentication',
	    parameters: [
	      {
	        name: 'name',
	        type: 'string'
	      },
	      {
	        name: 'url',
	        type: 'string',
	        description: 'testing desc'
	      }
	    ]
        }
      },
````
This change will enable us to create parameter with personalized name,type ,in,required and description