### PR TITLE
feat: Added disabled attribute

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,7 @@ check the **./swagger/swagger.json** for sample generated swagger documentation 
 It comes with some default settings which can be override by creating **config/swaggergenerator.js**
 ```javascript
 module.exports["swagger-generator"] = {
+    disabled: false,
     swaggerJsonPath: "./swagger/swagger.json",
     parameters: { //we can add up custom parameters here
         PerPageQueryParam: {
@@ -54,6 +55,7 @@ module.exports["swagger-generator"] = {
     }
 };
 ```
+* **disabled** attribute is used to disable the module. (e.g you may want to disable it on production)
 * **swaggerJsonPath** where to generate the `swagger.json` file to, default to `sails.config.appPath + "/swagger/swagger.json"`
 * **parameters** we can create your own custom parameter to be referenced by api service methods and it's totally based on swagger specification for parameter object. Any one added here is added to the default parameters which are
 ```javascript

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = function (sails) {
     return {
 
         defaults: {
+            disabled: false,
             __configKey__: {
                 swaggerJsonPath: sails.config.appPath + "/swagger/swagger.json",
                 parameters: { //we can add up custom parameters here

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -53,8 +53,6 @@ function _parseAttributes(attributes) {
 function _parseRoutes(routes) {
     var custom_routes = {};
 
-    console.log("our routes", routes);
-
     /**
      * we need to check for routes without verb or method
      * which means for a path allow any CRUD method (GET, PUT, POST, DELETE or PATCH) when a method is not specified

--- a/lib/swaggerDoc.js
+++ b/lib/swaggerDoc.js
@@ -4,7 +4,9 @@ var generators = require('./generators');
 var fs = require('fs');
 
 module.exports = function (sails, context) {
-
+    if (sails.config[context.configKey].disabled === true) {
+        return;
+    }
 
     var specifications = sails.config[context.configKey].swagger;
     specifications.tags = generators.tags(sails.models);


### PR DESCRIPTION
Since Sails doesn't allow modules to be disabled, I decided to pass a `disabled` parameter to disable swagger.

closes #21