### PR TITLE
Handle Path mixed with keys and path 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,2 @@
+let g:ale_fixers = {'javascript':[] }
+let g:ale_linters = {'javascript': []}

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -290,6 +290,8 @@ function _generatePaths(generated_routes, tags, customBlueprintMaps) {
 /**
  * help to process route keys to swagger spec format
  * which is {key} instead of sails default /:key
+ * and also keys with path like so /:key/path --> https://github.com/theo4u/sails-hook-swagger-generator/issues/24
+ *
  * @param keys
  * @returns {string}
  * @private
@@ -297,11 +299,18 @@ function _generatePaths(generated_routes, tags, customBlueprintMaps) {
 function _processRouteKeys(keys) {
 
     var map = _.map(keys, function (key) {
-        return "{" + key + "}";
+      // handle keys of such nature specified here: theo4u/sails-hook-swagger-generator#24
+      const keyWithPath = key.split('/');
+      var path = "";
+      if(keyWithPath[1]){
+        path = "/"+ keyWithPath[1]
+      }
+      return "{" + keyWithPath[0] + "}"+path;
     });
 
     return map.join("/");
 }
+
 
 /**
  * making our link string to look like this
@@ -332,12 +341,13 @@ function _getPathParamsFromKeys(keys) {
     var params = [];
 
     _.forEach(keys, function (key) {
+      const mainKey = key.split('/')[0]; // for keys coming as key/extra_path related to theo4u/sails-hook-swagger-generator#24
         params.push({
             in: 'path',
-            name: key,
+            name: mainKey,
             required: true,
             type: 'string',
-            description: 'This is a path param for ' + key
+            description: 'This is a path param for ' + mainKey
         });
     });
 

--- a/test/generators.test.js
+++ b/test/generators.test.js
@@ -459,7 +459,10 @@ describe('Generators', function () {
             }
         };
         var tags = generators.tags(models);
-        var generatedRoutes = generators.routes(controllers, {routes: {'get /user/phone/:phoneNumber': 'UserController.phone'}}, tags);
+      var generatedRoutes = generators.routes(controllers, {routes: {
+        'get /user/phone/:phoneNumber': 'UserController.phone',
+        'get /user/phone/:phoneNumber/call': 'UserController.phone'
+      }}, tags);
         var actual = generators.paths(generatedRoutes, tags, {list: [{$ref: '#/parameters/PerPageQueryParam'}]});
 
         it('should not create default paths like create, find, findOne, update and destroy for routes without models', function (done) {
@@ -511,6 +514,10 @@ describe('Generators', function () {
 
         it('should make sure every route keys has a corresponding path type of parameter', function (done) {
             expect(_.find(actual['/user/phone/{phoneNumber}'].get.parameters, {
+                name: 'phoneNumber',
+                in: 'path'
+            })).to.be.an('object');
+          expect(_.find(actual['/user/phone/{phoneNumber}/call'].get.parameters, {
                 name: 'phoneNumber',
                 in: 'path'
             })).to.be.an('object');


### PR DESCRIPTION
e.g `/users/:id/contact` before now it does this --> `/users/{id/contact}`. 
expected behaviour `/users/{id}/contact`